### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/diegoabeltran16/OpenPages-Source/security/code-scanning/1](https://github.com/diegoabeltran16/OpenPages-Source/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only reads repository contents (e.g., downloading dependencies and running tests), we will set `contents: read` as the minimal required permission. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
