### PR TITLE
test(D):(V3.R6.C4)

### DIFF
--- a/internal/transform/converter.go
+++ b/internal/transform/converter.go
@@ -300,10 +300,10 @@ func ConvertTiddlersV3(ts []models.Tiddler) []map[string]any {
 		obj := map[string]any{
 			"id":           t.Title,
 			"title":        t.Title,
-			"created":      orEmpty(created),
-			"created_rfc":  createdStr,
-			"modified":     orEmpty(modified),
-			"modified_rfc": modifiedStr,
+			"created":      createdStr,        // <-- ahora RFC3339
+			"created_raw":  orEmpty(created),  // <-- opcional, el crudo
+			"modified":     modifiedStr,       // <-- ahora RFC3339
+			"modified_raw": orEmpty(modified), // <-- opcional, el crudo
 			"tags":         tags,
 			"tags_list":    tagsList,
 			"tmap.id":      orEmpty(tmapid),

--- a/internal/transform/update_texts.go
+++ b/internal/transform/update_texts.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"testing"
 	"time"
 
 	"github.com/diegoabeltran16/OpenPages-Source/models"
@@ -24,4 +25,38 @@ func UpdateTexts(template []models.Tiddler, updates []models.Tiddler) []models.T
 		}
 	}
 	return template
+}
+
+func TestUpdateTexts(t *testing.T) {
+	plantilla := []models.Tiddler{
+		{Title: "A", Text: "foo", Modified: "20240101"},
+		{Title: "B", Text: "bar", Modified: "20240102"},
+	}
+	updates := []models.Tiddler{
+		{Title: "A", Text: "foo"},         // igual, no debe cambiar
+		{Title: "B", Text: "nuevo texto"}, // diferente, debe actualizarse
+	}
+
+	result := UpdateTexts(plantilla, updates)
+
+	// El texto de A no cambia, ni la fecha
+	if result[0].Text != "foo" || result[0].Modified != "20240101" {
+		t.Errorf("No debe cambiar el tiddler A")
+	}
+
+	// El texto de B cambia, y la fecha debe ser "ahora" (formato TiddlyWiki)
+	if result[1].Text != "nuevo texto" {
+		t.Errorf("Debe actualizar el texto de B")
+	}
+	if result[1].Modified == "20240102" {
+		t.Errorf("Debe actualizar la fecha de B")
+	}
+	if len(result) != 2 {
+		t.Errorf("No debe cambiar la cantidad de tiddlers")
+	}
+
+	// Verifica formato TiddlyWiki (14 dígitos numéricos)
+	if result[1].Modified == "" || len(result[1].Modified) != 14 {
+		t.Errorf("La fecha modificada debe tener formato TiddlyWiki (yyyymmddhhMMSS)")
+	}
 }


### PR DESCRIPTION
test(D): robustez en comparación y normalización de tiddlers + mejoras de conversión y actualización 

- Normalización de campos opcionales (mapas y slices) en internal/importer/reader_test.go para evitar falsos negativos por diferencias nil/vacío
- Ajustes en internal/transform/converter.go para asegurar fechas RFC3339 y robustez en conversión v3
- Refuerzo de la función y test de actualización de textos en internal/transform/update_texts.go
- Todos los tests pasan de forma robusta y reproducible, asegurando trazabilidad y confiabilidad del pipeline

# (V3.R6.C4 / gen=pipeline, b=1, ∆r=+0, ∆c=+0.2)